### PR TITLE
Support messages that include a reply & update editing/deleting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,24 +101,22 @@ impl EventHandler for Handler {
         }
 
         if custom_id == "remove" {
-            if let Err(why) = msg.delete(&ctx.http).await {
-                println!("Error deleting message: {:?}", why);
-                return;
-            }
-
-            // Deleted Message Response
-            let rsp_msg = msg.channel_id.say(&ctx.http, "💣 Deleted Message").await;
-            if let Err(why) = &rsp_msg {
-                println!("Error sending message: {:?}", why);
-            }
+            component
+            .edit_original_interaction_response(&ctx.http, |m| {
+                m.content("💣 Deleted Message").allowed_mentions(|am| am.empty_parse());
+                m.components(|c| c)
+            })
+            .await
+            .unwrap();
 
             // Sleep for 5 seconds
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
             // Delete the response message
-            if let Err(why) = rsp_msg.unwrap().delete(&ctx.http).await {
-                println!("Error deleting message: {:?}", why);
-            }
+            component
+            .delete_original_interaction_response(&ctx.http)
+            .await
+            .unwrap();
         } else {
             let mut new_msg = msg.content.clone();
 
@@ -128,8 +126,8 @@ impl EventHandler for Handler {
                 new_msg = new_msg.replace(VXTWITTER_URL, FXTWITTER_URL);
             }
 
-            msg.channel_id
-                .edit_message(&ctx.http, msg.id, |m| {
+            component
+                .edit_original_interaction_response(&ctx.http, |m| {
                     m.content(new_msg).allowed_mentions(|am| am.empty_parse())
                 })
                 .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,22 +101,23 @@ impl EventHandler for Handler {
         }
 
         if custom_id == "remove" {
-            component
-            .edit_original_interaction_response(&ctx.http, |m| {
+            if let Err(why) = component.edit_original_interaction_response(&ctx.http, |m| {
                 m.content("💣 Deleted Message").allowed_mentions(|am| am.empty_parse());
                 m.components(|c| c)
             })
             .await
-            .unwrap();
+            {
+                println!("Error editing message: {:?}", why);
+            }
 
             // Sleep for 5 seconds
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
 
             // Delete the response message
-            component
-            .delete_original_interaction_response(&ctx.http)
-            .await
-            .unwrap();
+            if let Err(why) = component.delete_original_interaction_response(&ctx.http)
+            .await {
+                println!("Error deleting message: {:?}", why);
+            }
         } else {
             let mut new_msg = msg.content.clone();
 
@@ -126,12 +127,12 @@ impl EventHandler for Handler {
                 new_msg = new_msg.replace(VXTWITTER_URL, FXTWITTER_URL);
             }
 
-            component
-                .edit_original_interaction_response(&ctx.http, |m| {
-                    m.content(new_msg).allowed_mentions(|am| am.empty_parse())
-                })
-                .await
-                .unwrap();
+            if let Err(why) = component.edit_original_interaction_response(&ctx.http, |m| {
+                m.content(new_msg).allowed_mentions(|am| am.empty_parse())
+            })
+            .await {
+                println!("Error editing message: {:?}", why);
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,9 @@ impl EventHandler for Handler {
             .channel_id
             .send_message(&context.http, |m| {
                 m.allowed_mentions(|am| am.empty_parse()).content(response);
+                if msg.referenced_message.is_some() {
+                    m.reference_message(msg.message_reference.clone().unwrap());
+                }
                 m.components(|f| {
                     f.create_action_row(|f| {
                         f.create_button(|b| {


### PR DESCRIPTION
This PR introduces the following changes:
- If the message containing the twitter link has a reply to another user's message, the bot will now recreate the reply to that user (without mentioning to prevent double pings from the original message). (resolves #2)
- Bot now edits it's own messages through the interaction response endpoints, instead of using the normal messages endpoint. This gives the added benefit of continuing to be able to use the components even if the bot loses access to the channel, and not being bound to the bot's [Global Rate Limit](<https://discord.com/developers/docs/topics/rate-limits#global-rate-limit>).
- When the "Remove" button is pressed, the bot now edits it's message to show it was deleted and then deletes the message, rather than deleting the message -> creating a new message -> then deleting that message.

## Screenshot

<img width="835" alt="image" src="https://github.com/tumGER/sphene/assets/46201432/b7e4cbd8-b420-4f46-a0be-266e6b0886c1">
